### PR TITLE
Feature/add config subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/jack-ohara/goblaze
 
 go 1.14
 
-require (
-	github.com/joho/godotenv v1.3.0
-)
+require golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
 github.com/jack-ohara/goblaze v0.0.0-20200322110430-c17f9e35b5e8 h1:0xki+7NYQIeZsr+SO+n+9KkdpQXIwPYS9ogK1NbFapM=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5 h1:Q7tZBpemrlsc2I7IyODzhtallWRSm4Q0d09pL6XbQtU=
+golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/goblaze/configuration/configuration.go
+++ b/goblaze/configuration/configuration.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"path"
 	"strings"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 type ConfigurationValues struct {
@@ -32,11 +35,39 @@ func GetUploadedFilesPath() string {
 	return path.Join(GetConfigDirectory(), "uploadedFiles.json")
 }
 
+func GetConfiguration() ConfigurationValues {
+	_, err := os.Stat(getConfigFilePath())
+
+	if os.IsNotExist(err) {
+		log.Fatal("Please call goblaze config first")
+	}
+
+	configFileData, err := ioutil.ReadFile(getConfigFilePath())
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	configValues := ConfigurationValues{}
+
+	err = json.Unmarshal(configFileData, &configValues)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return configValues
+}
+
 func SetupConfigFile() {
-	keyID := promptForValue("Please enter the key ID: ")
-	applicationKey := promptForValue("Please enter the application key: ")
-	bucketID := promptForValue("Please enter the ID of the backblaze bucket to use: ")
-	encryptionPassphrase := promptForValue("Please enter a passphrase to be used for encryption: ")
+	keyID := promptForValue("Please enter the key ID: ", false)
+	applicationKey := promptForValue("Please enter the application key: ", false)
+	bucketID := promptForValue("Please enter the ID of the backblaze bucket to use: ", false)
+	encryptionPassphrase := promptForValue("Please enter a passphrase to be used for encryption: ", true)
+
+	if encryptionPassphrase != promptForValue("Please re-enter your passphrase: ", true) {
+		log.Fatal("The two passwords do not match")
+	}
 
 	configValues := ConfigurationValues{
 		EncryptionPassphrase: encryptionPassphrase,
@@ -45,6 +76,37 @@ func SetupConfigFile() {
 		BucketID:             bucketID,
 	}
 
+	writeConfigValuesToFile(configValues)
+}
+
+func promptForValue(promptText string, secret bool) string {
+	fmt.Print(promptText)
+
+	if secret {
+		byteValue, err := terminal.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return string(byteValue)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+
+	text, _ := reader.ReadString('\n')
+	text = strings.ReplaceAll(text, "\r\n", "")
+	text = strings.ReplaceAll(text, "\n", "")
+
+	return text
+}
+
+func getConfigFilePath() string {
+	return path.Join(GetConfigDirectory(), "appConfig.json")
+}
+
+func writeConfigValuesToFile(configValues ConfigurationValues) {
 	jsonData, err := json.MarshalIndent(configValues, "", "  ")
 
 	if err != nil {
@@ -72,19 +134,4 @@ func SetupConfigFile() {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func promptForValue(promptText string) string {
-	reader := bufio.NewReader(os.Stdin)
-
-	fmt.Print(promptText)
-	text, _ := reader.ReadString('\n')
-	text = strings.ReplaceAll(text, "\n", "")
-	text = strings.ReplaceAll(text, "\r\n", "")
-
-	return text
-}
-
-func getConfigFilePath() string {
-	return path.Join(GetConfigDirectory(), "appConfig.json")
 }

--- a/goblaze/configuration/configuration.go
+++ b/goblaze/configuration/configuration.go
@@ -1,0 +1,90 @@
+package configuration
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+)
+
+type ConfigurationValues struct {
+	EncryptionPassphrase string
+	KeyID                string
+	ApplicationKey       string
+	BucketID             string
+}
+
+func GetConfigDirectory() string {
+	userHomeDir, err := os.UserHomeDir()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return path.Join(userHomeDir, ".goblaze")
+}
+
+func GetUploadedFilesPath() string {
+	return path.Join(GetConfigDirectory(), "uploadedFiles.json")
+}
+
+func SetupConfigFile() {
+	keyID := promptForValue("Please enter the key ID: ")
+	applicationKey := promptForValue("Please enter the application key: ")
+	bucketID := promptForValue("Please enter the ID of the backblaze bucket to use: ")
+	encryptionPassphrase := promptForValue("Please enter a passphrase to be used for encryption: ")
+
+	configValues := ConfigurationValues{
+		EncryptionPassphrase: encryptionPassphrase,
+		KeyID:                keyID,
+		ApplicationKey:       applicationKey,
+		BucketID:             bucketID,
+	}
+
+	jsonData, err := json.MarshalIndent(configValues, "", "  ")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	configFilePath := getConfigFilePath()
+
+	if _, err := os.Stat(GetConfigDirectory()); os.IsNotExist(err) {
+		os.MkdirAll(GetConfigDirectory(), os.ModePerm)
+	}
+
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		file, err := os.Create(configFilePath)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		file.Close()
+	}
+
+	err = ioutil.WriteFile(getConfigFilePath(), jsonData, os.ModePerm)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func promptForValue(promptText string) string {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Print(promptText)
+	text, _ := reader.ReadString('\n')
+	text = strings.ReplaceAll(text, "\n", "")
+	text = strings.ReplaceAll(text, "\r\n", "")
+
+	return text
+}
+
+func getConfigFilePath() string {
+	return path.Join(GetConfigDirectory(), "appConfig.json")
+}

--- a/goblaze/goblaze.go
+++ b/goblaze/goblaze.go
@@ -42,7 +42,7 @@ func UploadDirectory(directoryPath, encryptionPassphrase, bucketID string, autho
 	lock := sync.RWMutex{}
 
 	var wg sync.WaitGroup
-	allFiles := getFilePaths(directoryPath, uploadedFiles)
+	allFiles := getFilePaths(strings.ReplaceAll(directoryPath, "\\", "/"), uploadedFiles)
 
 	numberOfRequests := 0
 

--- a/goblaze/goblaze.go
+++ b/goblaze/goblaze.go
@@ -131,7 +131,7 @@ func uploadFile(filePath, encryptionPassphrase, bucketID string, authorizationIn
 	if uploadResponse.StatusCode == 200 {
 		log.Println("Successfully uploaded file ", filePath)
 
-		writeUploadedFileToMap(lock, uploadedFiles, filePath, uploadResponse.FileID)
+		writeUploadedFileToMap(lock, uploadedFiles, filePath, uploadResponse.FileID, uploadResponse.LargeFile)
 	} else {
 		log.Printf("The uploading of the file %s returned a status code of %d\n", filePath, uploadResponse.StatusCode)
 	}
@@ -139,13 +139,13 @@ func uploadFile(filePath, encryptionPassphrase, bucketID string, authorizationIn
 	(*onCompletionFunc)()
 }
 
-func writeUploadedFileToMap(lock *sync.RWMutex, uploadedFiles *uploadedfiles.UploadedFiles, filePath, fileID string) {
+func writeUploadedFileToMap(lock *sync.RWMutex, uploadedFiles *uploadedfiles.UploadedFiles, filePath, fileID string, largeFile bool) {
 	(*lock).Lock()
 	defer (*lock).Unlock()
 
 	log.Printf("Adding %s to uploadedFiles. FileId: %s\n", filePath, fileID)
 
-	(*uploadedFiles)[filePath] = uploadedfiles.UploadedFileInfo{LastUploadedTime: time.Now(), FileID: fileID}
+	(*uploadedFiles)[filePath] = uploadedfiles.UploadedFileInfo{LastUploadedTime: time.Now(), FileID: fileID, LargeFile: largeFile}
 
 	uploadedfiles.WriteUploadedFiles(*uploadedFiles)
 }

--- a/goblaze/uploadedfiles/uploadedfiles.go
+++ b/goblaze/uploadedfiles/uploadedfiles.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"time"
+
+	"github.com/jack-ohara/goblaze/goblaze/configuration"
 )
 
 type UploadedFileInfo struct {
@@ -18,12 +19,8 @@ type UploadedFileInfo struct {
 type UploadedFiles map[string]UploadedFileInfo
 
 func GetUploadedFiles() UploadedFiles {
-	if _, err := os.Stat(getConfigDirectory()); os.IsNotExist(err) {
-		os.MkdirAll(getConfigDirectory(), os.ModePerm)
-	}
-
-	if _, err := os.Stat(getConfigFilePath()); os.IsNotExist(err) {
-		file, err := os.Create(getConfigFilePath())
+	if _, err := os.Stat(configuration.GetUploadedFilesPath()); os.IsNotExist(err) {
+		file, err := os.Create(configuration.GetUploadedFilesPath())
 
 		if err != nil {
 			log.Fatal(err)
@@ -32,7 +29,7 @@ func GetUploadedFiles() UploadedFiles {
 		file.Close()
 	}
 
-	fileContents, err := ioutil.ReadFile(getConfigFilePath())
+	fileContents, err := ioutil.ReadFile(configuration.GetUploadedFilesPath())
 
 	if err != nil {
 		log.Fatal(err)
@@ -51,23 +48,9 @@ func WriteUploadedFiles(uploadedFiles UploadedFiles) {
 		log.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(getConfigFilePath(), jsonContent, os.ModePerm)
+	err = ioutil.WriteFile(configuration.GetUploadedFilesPath(), jsonContent, os.ModePerm)
 
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-func getConfigDirectory() string {
-	userHomeDir, err := os.UserHomeDir()
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return path.Join(userHomeDir, ".goblaze")
-}
-
-func getConfigFilePath() string {
-	return path.Join(getConfigDirectory(), "uploadedFiles.json")
 }

--- a/main.go
+++ b/main.go
@@ -4,9 +4,11 @@ import (
 	"flag"
 	"log"
 	"os"
+	"path"
 
 	"github.com/jack-ohara/goblaze/goblaze"
 	"github.com/jack-ohara/goblaze/goblaze/accountauthorization"
+	"github.com/jack-ohara/goblaze/goblaze/configuration"
 	"github.com/joho/godotenv"
 )
 
@@ -18,13 +20,9 @@ type configurationValues struct {
 }
 
 func main() {
-	err := godotenv.Load()
+	dotenverr := godotenv.Load(path.Join(configuration.GetConfigDirectory(), ".env"))
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	configValues := getEnvironmentVariables()
+	configCommand := flag.NewFlagSet("config", flag.ExitOnError)
 
 	uploadCommand := flag.NewFlagSet("upload", flag.ExitOnError)
 	uploadDirectory := uploadCommand.String("dir", "", "Identifies the directory to upload")
@@ -35,11 +33,23 @@ func main() {
 	downloadWriteMode := downloadCommand.Int("write-mode", 1, "Value of 0: Does not overwrite the file if it already exists\nValue of 1: Overwrites existing files if the downloaded file is more recent\nValue of 2: Overwrites any existing files")
 
 	switch os.Args[1] {
+	case "config":
+		configCommand.Parse(os.Args[2:])
+
+		if len(configCommand.Args()) > 0 {
+			log.Fatalln("Unexpected arguments to goblaze config: ", uploadCommand.Args())
+		}
+
+		configuration.SetupConfigFile()
 	case "upload":
 		uploadCommand.Parse(os.Args[2:])
 
 		if len(uploadCommand.Args()) > 0 {
 			log.Fatalln("Unexpected arguments to goblaze upload: ", uploadCommand.Args())
+		}
+
+		if dotenverr != nil {
+			log.Fatalln("Please run 'goblaze config' first")
 		}
 
 		fileInfo, err := os.Stat(*uploadDirectory)
@@ -51,6 +61,8 @@ func main() {
 		if !fileInfo.IsDir() {
 			log.Fatalln("Expected 'dir' argument to point to a directory but it is a file: ", *uploadDirectory)
 		}
+
+		configValues := getEnvironmentVariables()
 
 		authorizationInfo := accountauthorization.GetAccountAuthorization(configValues.KeyID, configValues.ApplicationKey)
 
@@ -75,6 +87,8 @@ func main() {
 		if *downloadWriteMode != 0 && *downloadWriteMode != 1 && *downloadWriteMode != 2 {
 			log.Fatalln("Invalid value for write-mode: ", *downloadWriteMode)
 		}
+
+		configValues := getEnvironmentVariables()
 
 		authorizationInfo := accountauthorization.GetAccountAuthorization(configValues.KeyID, configValues.ApplicationKey)
 


### PR DESCRIPTION
Added a 'config' subcommand that will need to be run first by the user. This will put all of the user's config into a known file, which will remove the limitation of having to run from within the .goblaze directory.

Also fixed a bug with reporting on large files, which would stop downloading from working 